### PR TITLE
Settings: Move "Double-tap to sleep" option under Display settings

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -759,6 +759,10 @@ two in order to insert additional control points. \'Remove\' deletes the selecte
     <!-- tap-to-wake -->
     <string name="double_tap_to_wake_title">Double-tap to wake</string>
 
+    <!-- tap-to-sleep -->
+    <string name="double_tap_to_sleep_title">Double-tap to sleep</string>
+    <string name="double_tap_to_sleep_summary">Double tap status bar or lock screen slider to put the device to sleep</string>
+
     <!-- Proximity wake -->
     <string name="proximity_wake_title">Prevent accidental wake-up</string>
     <string name="proximity_wake_summary">Check the proximity sensor prior to waking up screen</string>
@@ -997,7 +1001,6 @@ two in order to insert additional control points. \'Remove\' deletes the selecte
     <string name="status_bar_toggle_info">Not available while automatic brightness is enabled</string>
     <string name="status_bar_notif_count_title">Show notification count</string>
     <string name="status_bar_notif_count_summary">Display the number of pending notifications</string>
-    <string name="status_bar_double_tap_to_sleep_title">Double-tap to sleep</string>
 
     <!-- Development shortcut -->
     <string name="development_shortcut_title">Development shortcut</string>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -120,6 +120,12 @@
                 android:summary="@string/color_enhancement_summary"
                 android:defaultValue="true" />
 
+            <com.android.settings.cyanogenmod.SystemSettingCheckBoxPreference
+                android:key="double_tap_sleep_gesture"
+                android:title="@string/double_tap_to_sleep_title"
+                android:summary="@string/double_tap_to_sleep_summary"
+                android:defaultValue="false" />
+
             <CheckBoxPreference
                 android:key="double_tap_wake_gesture"
                 android:title="@string/double_tap_to_wake_title"

--- a/res/xml/status_bar.xml
+++ b/res/xml/status_bar.xml
@@ -58,9 +58,4 @@
         android:summary="@string/status_bar_notif_count_summary"
         android:defaultValue="false" />
 
-    <com.android.settings.cyanogenmod.SystemSettingCheckBoxPreference
-        android:key="double_tap_sleep_gesture"
-        android:title="@string/status_bar_double_tap_to_sleep_title"
-        android:defaultValue="false" />
-
 </PreferenceScreen>


### PR DESCRIPTION
Move dt2s above dt2w option so users don't get confused.

Change-Id: I910eb6624536b437d0bf14f64c1eeacafaa59cfa
