### PR TITLE
Settings: Rename GPS tile to Location tile

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -349,7 +349,7 @@
     <string name="title_tile_compass">Compass</string>
     <string name="title_tile_heads_up">Heads up</string>
     <string name="title_tile_sleep">Go to sleep</string>
-    <string name="title_tile_gps">GPS</string>
+    <string name="title_tile_gps">Location</string>
     <string name="title_tile_torch">Torch</string>
     <string name="title_tile_lockscreen">Lock screen</string>
     <string name="title_tile_lte">LTE</string>


### PR DESCRIPTION
- This tile no longer affects the GPS only but toggles other location modes too

Change-Id: Ic960aee08637520c6914bbfaa22f1d788ae67fc3
