### PR TITLE
msim: Use the SIM operator to label the subscription

### DIFF
--- a/src/com/android/settings/MultiSimSettings.java
+++ b/src/com/android/settings/MultiSimSettings.java
@@ -175,7 +175,7 @@ public class MultiSimSettings extends PreferenceActivity implements DialogInterf
         int i = 0;
         for (i = 0; i < MAX_SUBSCRIPTIONS; i++) {
             String operatorName = tm.getSimState(i) != SIM_STATE_ABSENT
-                    ? tm.getNetworkOperatorName(i) : getString(R.string.sub_no_sim);
+                    ? tm.getSimOperatorName(i) : getString(R.string.sub_no_sim);
             String label = getString(R.string.multi_sim_entry_format, operatorName, i + 1);
             entries[i] = summaries[i] = label;
             entriesPrompt[i] = summariesPrompt[i] = label;

--- a/src/com/android/settings/SelectSubscription.java
+++ b/src/com/android/settings/SelectSubscription.java
@@ -76,7 +76,7 @@ public class SelectSubscription extends  TabActivity {
 
         for (int i = 0; i < numPhones; i++) {
             String operatorName = tm.getSimState(i) != SIM_STATE_ABSENT
-                    ? tm.getNetworkOperatorName(i) : getString(R.string.sub_no_sim);
+                    ? tm.getSimOperatorName(i) : getString(R.string.sub_no_sim);
             String label = getString(R.string.multi_sim_entry_format, operatorName, i + 1);
             subscriptionPref = tabHost.newTabSpec(label);
             subscriptionPref.setIndicator(label);


### PR DESCRIPTION
network operator is confusing, and downright misleading in roaming
cases

Change-Id: I3f645bbf1191f086ec0b6ca6cc8669915b2902a4
